### PR TITLE
Fix ISR data races and out-of-bounds write in clock firmware

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,17 @@ isn't lost again. Items are grouped into tracks; tracks can progress in parallel
   firmware task.)
 - **Unreadable on purpose.** The whole point is a clock that is hard to read but
   still gives an analog sense of time passing.
+- **Outsource fabrication, minimize hand-assembly.** The maintainer is strong on
+  software but not on hands-on building, so prefer designs that can be
+  manufactured and assembled by a service (PCB assembly / printed enclosures)
+  rather than hand-soldered or hand-fitted — as long as it stays reasonably
+  inexpensive at hobby quantities. Concretely: favor turnkey **PCBA** (board +
+  parts placed and reflowed by the fab), off-the-shelf modules over discrete
+  bring-up, connectors/sockets over soldered-in wiring, and enclosure processes
+  available from print/CNC service bureaus over methods needing a home shop. The
+  CERN-OHL-S license already permits third parties (including fab houses) to make
+  the hardware, so this is purely a design-choice principle. Avoid low-volume
+  injection molding and anything that only pencils out at industrial quantities.
 
 ## Track A — Repository & firmware hygiene (in progress)
 
@@ -23,8 +34,13 @@ isn't lost again. Items are grouped into tracks; tracks can progress in parallel
       block in `fastled_strand_test`.
 - [x] Move dev sketches out of `test/` (reserved for unit tests) into `examples/`.
 - [x] Add dual licensing (MIT firmware + CERN-OHL-S hardware).
-- [ ] Add continuous integration that builds the firmware with PlatformIO.
+- [x] Add continuous integration that builds the firmware with PlatformIO.
 - [ ] Pin `lib_deps` versions for reproducible builds.
+- [ ] **Produce manufacturing outputs for the existing board** so it can be sent
+      to a PCBA service without a home shop: export Gerbers + drill, an
+      assembly-house BOM, and a centroid/pick-and-place (CPL) file from the EAGLE
+      design, and check them into `pcb/`. (Needs EAGLE/CAD tooling; first step
+      toward the outsource-fabrication principle.)
 - [ ] **Firmware correctness pass** (from the resurrection audit):
   - [x] Mark ISR-shared globals `volatile` (`ppsStartOfSecondMillis`,
         `ppsStartOfMinuteMillis`, `currentMinute`, `nextLeapMinute`,
@@ -87,38 +103,56 @@ Concrete behaviors `AbimcRender` (and the no-signal display) must implement:
 ## Track C — Hardware v2 (deferred; no hardware change yet)
 
 Captured for when we're ready. Current decision is to **keep the existing
-ItsyBitsy M4 hardware** and do the software work first.
+ItsyBitsy M4 hardware** and do the software work first. Design this revision for
+**turnkey manufacturing** per the outsourcing principle: one assembled PCB from a
+PCBA service rather than a dev board plus hand-wiring.
 
 - **MCU candidates if/when we revise:** ESP32-S3 (Wi-Fi/BLE, NTP, OTA, BLE config)
   or RP2350/Pico 2 W (PIO-driven LEDs, deterministic timing). Either would keep
-  GPS as the primary, offline time source per the guiding principles.
+  GPS as the primary, offline time source per the guiding principles. **Prefer a
+  bare module the fab can place** (e.g. ESP32-S3-WROOM, RP2350 + flash) so there
+  is no separate dev board to hand-solder; pick parts from the assembler's
+  standard library (e.g. JLCPCB basic/extended) to keep PCBA cheap.
 - **LEDs:** stay with APA102-class (separate clock line = high PWM refresh and
   global brightness, which makes smooth moving hands look good). Move to the
   smaller APA102-2020 / SK9822 package to enable the desk-size shrink; custom
-  flex-PCB rings at small diameters.
+  flex-PCB rings at small diameters — and have the **LEDs placed by the fab**
+  (hand-placing hundreds of 2020 parts is exactly what we're trying to avoid).
 - **GPS:** upgrade the 6-year-old MTK3339/XA1110 to a u-blox MAX-M10S — better
   sensitivity, lower power, still has PPS, and reports current + pending leap
   seconds directly (UBX-NAV-TIMELS), which would greatly simplify the leap-second
-  code.
+  code. A drop-in **castellated GPS module** the assembler can reflow is ideal.
 - **RTC:** add a battery-backed DS3231 so time survives power loss without
-  reacquiring a fix.
+  reacquiring a fix. Use a battery **holder/socket**, not a soldered-in cell.
 - **Power:** budget carefully — 504 APA102 at full white is a theoretical ~30 A;
-  rely on brightness limiting and the sparse hands-only display.
+  rely on brightness limiting and the sparse hands-only display. Use a standard
+  barrel-jack/USB-C input module so power is plug-in, not wired.
+- **Assembly aim:** the only manual steps should be plugging the ring PCBs into
+  the main board via connectors and closing the enclosure — no soldering.
 
 ## Track D — Desk-sized enclosure (future)
 
-The original clock was too big. Shrink it to a desk-sized unit.
+The original clock was too big. Shrink it to a desk-sized unit, using enclosure
+processes available from **online print/CNC service bureaus** (FDM/SLA 3D
+printing, laser-cut acrylic) rather than anything needing a home workshop.
 
 - Recompute ring radii for a ~100-150 mm diameter target.
-- Smaller infinity-mirror stack and a 3D-printed housing.
+- Smaller infinity-mirror stack and a 3D-printed housing — order prints from a
+  service (e.g. JLCPCB/PCBWay 3D printing, Craftcloud, SendCutSend for acrylic)
+  and design for that process (tolerances, no support-heavy geometry, snap-fits
+  or screw bosses instead of glue where possible).
 - Let this constrain the Track B/C PCB so the electronics are designed for
   desk-scale ring counts up front, even if the first v2 build is larger.
+- Keep the parts count low and the assembly tool-free so a non-handy builder can
+  finish it from manufactured parts.
 
 ## Track E — Magnet-based configuration (future)
 
 Configure the clock by dropping small magnets into recesses molded into the 3D
 printed back panel. Magnets are non-volatile with no battery, so configuration
-survives power loss inherently.
+survives power loss inherently. The recesses are printed into the housing (a
+service print), and the Hall sensors are placed by the PCBA, so this needs no
+hand-assembly.
 
 - **Sensing:** digital Hall-effect sensors (e.g., DRV5032), one per recess; use
   *omnipolar* parts so magnet orientation doesn't matter. Route many sensors

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,18 +26,20 @@ isn't lost again. Items are grouped into tracks; tracks can progress in parallel
 - [ ] Add continuous integration that builds the firmware with PlatformIO.
 - [ ] Pin `lib_deps` versions for reproducible builds.
 - [ ] **Firmware correctness pass** (from the resurrection audit):
-  - [ ] Mark ISR-shared globals `volatile` (`ppsStartOfSecondMillis`,
+  - [x] Mark ISR-shared globals `volatile` (`ppsStartOfSecondMillis`,
         `ppsStartOfMinuteMillis`, `currentMinute`, `nextLeapMinute`,
         `numberOfLeapSeconds`).
-  - [ ] Fix the "torn read" guard in `setClock()` (currently compares a value to
-        itself and only re-reads once).
-  - [ ] Bound the array writes in `updateStrandSeconds()` (currently can index
-        past the end of a ring) before re-enabling the seconds feature.
+  - [x] Fix the "torn read" guard in `setClock()` (replaced the self-comparison
+        with a `noInterrupts()` snapshot of the minute/start-of-minute pair).
+  - [x] Bound the array writes in `updateStrandSeconds()` (now wraps with `MOD`)
+        so the seconds feature is safe to re-enable.
   - [ ] Actually populate `numberOfLeapSeconds` / `nextLeapMinute` from the parsed
         GPS leap-second fields, or remove the dead parsing — today the leap-second
         feature is wired up but never fed any data.
   - [ ] Finish or remove the commented-out seconds "ripple" rendering.
-  - [ ] Polish the VCR `12:00` flash for the no-signal state.
+  - [x] Polish the VCR `12:00` flash for the no-signal state — reviewed; the loop
+        already blinks `set12oClock()` at ~1 Hz while GPS time is invalid, which is
+        the intended VCR behavior. No change needed beyond confirming it.
 
 ## Track B — Library extraction (next)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,7 +71,10 @@ Concrete behaviors `AbimcRender` (and the no-signal display) must implement:
   all hands should point straight up. After such a hand passes the bottom of its
   ring, speed it up slightly so it reaches the top exactly as the minutes roll
   over to `:00`. (Verify whether the current `ST()`/period math already does
-  this — believed not yet implemented.)
+  this — believed not yet implemented.) The same catch-up applies one level down
+  to the **seconds within a minute**: 60 seconds mapped onto a power-of-two
+  period second hand must likewise speed up after the bottom so it reaches the
+  top exactly as the second hand completes the minute.
 - **Leap-second pacing.** Conversely, during a minute that contains a leap second
   the hands should move one second slower (or faster, for a removed second) so a
   61- (or 59-) second minute still lands the hands correctly at the rollover.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,6 +56,31 @@ tested on a PC via `pio test`, turning `test/` into real tests.
   persistence. Back-end for the magnet UI below.
 - `abimc_pcb` — already a library; keep, versioned per board revision.
 
+### Renderer motion & display rules (planned)
+
+Concrete behaviors `AbimcRender` (and the no-signal display) must implement:
+
+- **Hands never jump.** Define a `MAX_HAND_SPEED` (always greater than the
+  fastest *normal* speed of the 1-minute hand) and, whenever a hand's target
+  position differs from where it is now, advance it toward the target at that
+  capped speed instead of snapping. This smooths out time corrections and the
+  catch-up below.
+- **60 minutes on a 64-"minute" ring.** The rings run on power-of-two periods
+  (…32, 64), so a 64-period ring only travels 60/64 of the way around in a real
+  hour and would sit ~4 minutes short of the top at the turn of the hour, when
+  all hands should point straight up. After such a hand passes the bottom of its
+  ring, speed it up slightly so it reaches the top exactly as the minutes roll
+  over to `:00`. (Verify whether the current `ST()`/period math already does
+  this — believed not yet implemented.)
+- **Leap-second pacing.** Conversely, during a minute that contains a leap second
+  the hands should move one second slower (or faster, for a removed second) so a
+  61- (or 59-) second minute still lands the hands correctly at the rollover.
+  This ties into wiring up `numberOfLeapSeconds` / `nextLeapMinute`.
+- **Timezone-aware no-signal flash.** The "no time acquired yet" flash is
+  normally `12:00` (VCR style), but it should depend on the active timezone /
+  custom profile: when the **Margaritaville** timezone is in effect, flash `17`
+  ("it's 5 o'clock somewhere") instead of `12`.
+
 ## Track C — Hardware v2 (deferred; no hardware change yet)
 
 Captured for when we're ready. Current decision is to **keep the existing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,12 +115,16 @@ TinyGPSCustom pmtk667LeapSecondUtcWeekNumber(gps, "GNZDA", 8);
 TinyGPSCustom pmtk667LeapSecondDayOfWeek(gps, "GNZDA", 9);
 TinyGPSCustom pmtk667NewLeapSecondOffset(gps, "GNZDA", 10);
 
-time_t currentMinute = 0;
-time_t nextLeapMinute = 0;
-int numberOfLeapSeconds = 0;
-unsigned long ppsStartOfSecondMillis;  // Used for drift calculation
-unsigned long ppsStartOfMinuteMillis;  // Used with currentMinute to get complete millisecond precision time, accounting
-// for leap seconds
+// These are shared between the PPS interrupt (pps()) and the main loop, so they
+// must be volatile to stop the compiler from caching stale copies in registers.
+// On this 32-bit MCU aligned word accesses are atomic, so individual reads are
+// safe; setClock() additionally snapshots the related pair under noInterrupts().
+volatile time_t currentMinute = 0;
+volatile time_t nextLeapMinute = 0;
+volatile int numberOfLeapSeconds = 0;
+volatile unsigned long ppsStartOfSecondMillis = 0;  // Used for drift calculation
+volatile unsigned long ppsStartOfMinuteMillis = 0;  // Used with currentMinute to get complete millisecond precision
+// time, accounting for leap seconds
 
 unsigned long secondsInMinute(time_t minute) {
   return 60 + ((minute % 60) == (nextLeapMinute % 60) ? numberOfLeapSeconds : 0);
@@ -195,24 +199,30 @@ void updateStrandSeconds(CRGB* strand,
   if ((millisSinceStartOfMinute / 1000) % 2 > 0) {
     int secondHand = ST(offset, period * secondsInMinute(displayTime) * 1000, pixels, millisSinceStartOfHour);
     for (int i = 0; i < SECOND_HAND_WIDTH + 1; i++) {
-      strand[secondHand + i] += secondHandRender[i];
+      // Wrap around the ring like updateStrand() does; secondHand + i can run
+      // past the end of the strand otherwise.
+      strand[MOD(secondHand + i, pixels)] += secondHandRender[i];
     }
   }
 }
 
 void setClock() {
-  // Get timestamp
+  // Take a consistent snapshot of the values the PPS interrupt updates. The
+  // interrupt writes currentMinute and ppsStartOfMinuteMillis together on a
+  // minute rollover, so copy the pair with interrupts disabled to avoid reading
+  // one of them from before the rollover and the other from after.
+  noInterrupts();
+  time_t snapshotMinute = currentMinute;
   unsigned long displayStartOfMinuteMillis = ppsStartOfMinuteMillis;
-  time_t displayTime = myTZ.toLocal(currentMinute);
+  interrupts();
+
+  time_t displayTime = myTZ.toLocal(snapshotMinute);
   unsigned long displayMillis = millis();
-  if (displayStartOfMinuteMillis != ppsStartOfMinuteMillis) {
-    displayStartOfMinuteMillis = ppsStartOfMinuteMillis;
-    displayTime = myTZ.toLocal(currentMinute);
-    displayMillis = millis();
-  }
+
   // Determine hand positions
   unsigned long millisSinceStartOfMinute = displayMillis - displayStartOfMinuteMillis;
   unsigned long millisSinceStartOfSecond = millisSinceStartOfMinute % 1000;
+  (void)millisSinceStartOfSecond;  // consumed by the (currently disabled) seconds-hand render below
   unsigned long millisSinceStartOfHour = (displayTime % 3600) * 1000 + millisSinceStartOfMinute;
 
   // Determine color offset (PERIOD_IN_SECONDS * 1024 milliseconds / 256 colors in range)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -209,15 +209,18 @@ void updateStrandSeconds(CRGB* strand,
 void setClock() {
   // Take a consistent snapshot of the values the PPS interrupt updates. The
   // interrupt writes currentMinute and ppsStartOfMinuteMillis together on a
-  // minute rollover, so copy the pair with interrupts disabled to avoid reading
-  // one of them from before the rollover and the other from after.
+  // minute rollover, so copy them with interrupts disabled to avoid reading one
+  // of them from before the rollover and the other from after. millis() is read
+  // inside the same critical section so the "now" reference shares the same time
+  // base -- otherwise a rollover in the gap could make millisSinceStartOfMinute
+  // exceed 60s for a frame.
   noInterrupts();
   time_t snapshotMinute = currentMinute;
   unsigned long displayStartOfMinuteMillis = ppsStartOfMinuteMillis;
+  unsigned long displayMillis = millis();
   interrupts();
 
   time_t displayTime = myTZ.toLocal(snapshotMinute);
-  unsigned long displayMillis = millis();
 
   // Determine hand positions
   unsigned long millisSinceStartOfMinute = displayMillis - displayStartOfMinuteMillis;


### PR DESCRIPTION
Follow-up to #11. First half of the firmware correctness pass from `ROADMAP.md` — the memory-safety bugs around the PPS interrupt. No behavioral change to the rendered clock; these are latent data races and an out-of-bounds write.

## The problem
`pps()` is an ISR (attached in `setup()`), and it shares `currentMinute`, `ppsStartOfSecondMillis`, and `ppsStartOfMinuteMillis` with the main loop — but nothing guarded that sharing.

## Fixes
- **`volatile` on the ISR-shared globals** so the compiler can't cache stale copies in registers across the loop. (Word accesses are atomic on this 32-bit MCU, so individual reads are fine once volatile.)
- **Rewrote the torn-read guard in `setClock()`.** The old code compared `ppsStartOfMinuteMillis` *to itself* and re-read at most once — it couldn't actually detect a mid-read interrupt. Replaced with a `noInterrupts()` snapshot that copies `currentMinute` and `ppsStartOfMinuteMillis` as a consistent pair (the ISR writes them together on a minute rollover).
- **Bounded the ring write in `updateStrandSeconds()`** with `MOD(...)`, matching `updateStrand()`. `secondHand + i` could previously index past the end of a strand. This makes the (still-disabled) seconds feature safe to re-enable later.
- Silenced the now-unused-variable warning for the disabled seconds path.

## Deliberately *not* in this PR (still open in ROADMAP)
- Wiring the parsed GPS leap-second fields into `numberOfLeapSeconds` / `nextLeapMinute` (or removing the dead parsing).
- Finishing or removing the commented-out seconds "ripple" render.

The **VCR `12:00` flash** item is ticked off as reviewed: the loop already blinks `set12oClock()` at ~1 Hz while GPS time is invalid, which is the intended behavior — no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAJ28v8jXB5RJFHovDxZVg)_