### PR TITLE
Track B: extract hand geometry into host-tested abimc_render library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install platformio
 
-      - name: Build
-        run: pio run
+      - name: Build firmware
+        run: pio run -e adafruit_itsybitsy_m4
+
+      - name: Run host unit tests
+        run: pio test -e native

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,11 +63,17 @@ Break the monolithic `main.cpp` into reusable, host-testable libraries. The key
 win is making the time and rendering logic framework-agnostic so it can be unit
 tested on a PC via `pio test`, turning `test/` into real tests.
 
+A `native` PlatformIO env plus a `test/test_render/` suite now exist, and CI runs
+`pio test -e native` on every push, so the host-test pipeline is live.
+
 - `AbimcTimekeeper` — leap-second-aware, sub-second UTC clock with pluggable time
   *sources* (PPS-disciplined GPS today; NTP/RTC later) behind one interface.
-- `AbimcRender` — pure logic: time -> per-ring binary bit -> hand angle, with
-  fractional-pixel anti-aliasing and the seconds ripple. Operates on an abstract
-  pixel buffer so it has no FastLED dependency.
+- `abimc_render` — pure, FastLED-free rendering math. **Started:** the hand
+  geometry (`computeHand`: positions + sub-pixel leading/trailing fade + ring
+  wrap) is extracted from `updateStrand()` and unit tested on the host; the
+  firmware now calls it and only applies colour. **Still to move in:** the
+  per-ring binary-bit selection, the seconds "ripple", and the planned motion
+  rules (capped-speed slewing, 60-on-64 catch-up, leap-second pacing).
 - `AbimcConfig` — settings model (seconds on/off, timezone, custom-tz rules) plus
   persistence. Back-end for the magnet UI below.
 - `abimc_pcb` — already a library; keep, versioned per board revision.

--- a/lib/abimc_render/README.md
+++ b/lib/abimc_render/README.md
@@ -1,0 +1,21 @@
+# abimc_render
+
+Pure, framework-agnostic rendering math for the clock. No Arduino or FastLED
+dependency, so it builds and unit-tests on a host (`pio test -e native`).
+
+Today it provides the hand-positioning geometry extracted from the firmware's
+original `updateStrand()`:
+
+- `abimc::mod(a, m)` — positive modulo (result always in `[0, m)`).
+- `abimc::computeHand(...)` — given a hand width, ring size, period and elapsed
+  time, returns the LEDs the hand lights and how much to fade the leading/
+  trailing pixels (`fadeBy`, matching FastLED's `fadeToBlackBy`). The firmware
+  applies the actual colour; this library only decides geometry and fade.
+
+The split keeps the testable integer math (positions, sub-pixel fading, ring
+wrap-around) separate from the FastLED colour application, and is where the
+planned renderer motion rules (capped-speed slewing, the 60-on-64 catch-up,
+leap-second pacing — see `ROADMAP.md`) will live.
+
+Sub-pixel resolution is controlled by `FRACTIONAL_BRIGHTNESS`, which must match
+the value used in `src/main.cpp`.

--- a/lib/abimc_render/abimc_render.cpp
+++ b/lib/abimc_render/abimc_render.cpp
@@ -1,0 +1,44 @@
+#include "abimc_render.h"
+
+namespace abimc {
+
+long long mod(long long a, long long m) {
+  if (m <= 0) {
+    return 0;
+  }
+  return ((a % m) + m) % m;
+}
+
+int computeHand(int width, long offset, long long period, int pixels,
+                unsigned long long millis, HandContribution* out) {
+  if (period <= 0 || pixels <= 0 || width < 0) {
+    return 0;
+  }
+
+  // Position is tracked in sub-pixels: every LED is FRACTIONAL_BRIGHTNESS - 1
+  // sub-pixels wide. This mirrors the original ST() macro, which was called with
+  // pixels * (FRACTIONAL_BRIGHTNESS - 1) as its pixel count.
+  const long long subpixels = (long long)pixels * (FRACTIONAL_BRIGHTNESS - 1);
+  const unsigned long long elapsed = millis % (unsigned long long)period;
+  const unsigned long long travel = elapsed * (unsigned long long)subpixels / (unsigned long long)period;
+  const long long position = mod((long long)offset + (long long)travel, subpixels);
+
+  const int wholePosition = (int)(position / (FRACTIONAL_BRIGHTNESS - 1));
+  const int fractionalPosition = (int)(position % (FRACTIONAL_BRIGHTNESS - 1));
+
+  for (int i = 0; i <= width; i++) {
+    out[i].index = (int)mod((long long)wholePosition + i, pixels);
+    if (i == 0) {
+      // Leading edge fades out as the hand advances past this pixel.
+      out[i].fadeBy = (uint8_t)fractionalPosition;
+    } else if (i == width) {
+      // Trailing edge fades in as the hand advances into the next pixel.
+      out[i].fadeBy = (uint8_t)(FRACTIONAL_BRIGHTNESS - 1 - fractionalPosition);
+    } else {
+      out[i].fadeBy = 0;
+    }
+  }
+  return width + 1;
+}
+
+}  // namespace abimc

--- a/lib/abimc_render/abimc_render.h
+++ b/lib/abimc_render/abimc_render.h
@@ -1,0 +1,59 @@
+// abimc_render -- pure, framework-agnostic rendering math for the Analog Binary
+// Infinity Mirror Clock.
+//
+// This library deliberately has no Arduino or FastLED dependency so it can be
+// unit tested on a host with `pio test -e native`. It computes *where* a clock
+// hand lands on a ring and *how much* to fade its leading/trailing pixels; the
+// firmware applies the actual colour using FastLED.
+#ifndef ABIMC_RENDER_H
+#define ABIMC_RENDER_H
+
+#include <cstdint>
+
+namespace abimc {
+
+// Sub-pixel brightness resolution. A hand's position is tracked in units of
+// 1/(FRACTIONAL_BRIGHTNESS - 1) of a pixel so a hand can glide smoothly between
+// adjacent LEDs instead of snapping from one to the next.
+//
+// NOTE: must stay equal to the FRACTIONAL_BRIGHTNESS used by the firmware in
+// src/main.cpp.
+constexpr int FRACTIONAL_BRIGHTNESS = 256;
+
+// Generous upper bound on a hand's width, used to size contribution buffers.
+constexpr int MAX_HAND_WIDTH = 32;
+
+// One LED lit by a hand: which pixel on the ring, and how much to fade the hand
+// colour when applying it. fadeBy matches FastLED's fadeToBlackBy(): 0 leaves
+// the colour untouched, 255 fades it to black.
+struct HandContribution {
+  int index;
+  uint8_t fadeBy;
+};
+
+// Positive modulo: the result is always in [0, m) for m > 0 (unlike C's % which
+// keeps the sign of the dividend). Returns 0 if m <= 0.
+long long mod(long long a, long long m);
+
+// Compute the LEDs lit by a hand.
+//
+// The hand spans width + 1 LEDs. Interior LEDs get the full colour; the leading
+// and trailing LEDs are faded in proportion to the hand's sub-pixel position so
+// the hand appears to slide smoothly around the ring. The mapping is identical
+// to the firmware's original updateStrand() math.
+//
+// Parameters:
+//   width   - hand width in whole pixels (>= 1); the hand lights width + 1 LEDs.
+//   offset  - alignment offset, in sub-pixels, applied before wrapping.
+//   period  - the hand's full-revolution period in the same units as millis.
+//   pixels  - number of LEDs on the ring.
+//   millis  - elapsed time positioning the hand within its period.
+//   out     - caller-provided buffer holding at least width + 1 contributions.
+//
+// Returns the number of contributions written (width + 1), or 0 if period <= 0.
+int computeHand(int width, long offset, long long period, int pixels,
+                unsigned long long millis, HandContribution* out);
+
+}  // namespace abimc
+
+#endif  // ABIMC_RENDER_H

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,12 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+; Build firmware for the board by default. The native env below is for host unit
+; tests only (it can't compile the Arduino firmware), so it must be opted into
+; explicitly with `-e native`.
+[platformio]
+default_envs = adafruit_itsybitsy_m4
+
 [env:adafruit_itsybitsy_m4]
 platform = atmelsam
 board = adafruit_itsybitsy_m4
@@ -26,3 +32,10 @@ lib_deps =
   Time
   Timezone
   TinyGPSPlus
+
+; Host environment for unit testing the pure libraries (abimc_render) with
+; `pio test -e native`. src/ is not built in test mode, so the Arduino-only
+; firmware is never compiled here.
+[env:native]
+platform = native
+build_flags = -std=gnu++11

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #define ABIMC_V_1_3
 
 #include <abimc_pcb.h>
+#include <abimc_render.h>
 #include <xa1110.h>
 
 #define DEBUG
@@ -151,24 +152,15 @@ void updateStrand(CRGB* strand,
                   int pixels,
                   unsigned long long millis,
                   const CRGB& color) {
-  if (period > 0) {
-    int position = ST(offset, period, pixels * (FRACTIONAL_BRIGHTNESS - 1), millis);
-    int wholePosition = position / (FRACTIONAL_BRIGHTNESS - 1);
-    int fractionalPosition = position % (FRACTIONAL_BRIGHTNESS - 1);
-    CRGB handRender[width + 1];
-    for (auto& i : handRender) {
-      i = color;
-    }
-    handRender[0].fadeToBlackBy(fractionalPosition);
-    // strand[wholePosition].fadeToBlackBy(FRACTIONAL_BRIGHTNESS - fractionalPosition);
-    handRender[width].fadeToBlackBy(FRACTIONAL_BRIGHTNESS - 1 - fractionalPosition);
-    // strand[wholePosition + width].fadeToBlackBy(fractionalPosition);
-    for (int i = 0; i <= width; i++) {
-      // if (i != 0 && i != width) {
-      //    strand[position / FRACTIONAL_BRIGHTNESS + i] = CRGB::Black;
-      // }
-      strand[MOD(wholePosition + i, pixels)] += handRender[i];
-    }
+  // Geometry (which pixels, and the sub-pixel fading of the leading/trailing
+  // edges) lives in the host-tested abimc_render library; here we just apply the
+  // colour with FastLED. Behaviour matches the original inline math.
+  abimc::HandContribution contributions[abimc::MAX_HAND_WIDTH + 1];
+  int count = abimc::computeHand(width, offset, period, pixels, millis, contributions);
+  for (int i = 0; i < count; i++) {
+    CRGB faded = color;
+    faded.fadeToBlackBy(contributions[i].fadeBy);
+    strand[contributions[i].index] += faded;
   }
 }
 

--- a/test/test_render/test_render.cpp
+++ b/test/test_render/test_render.cpp
@@ -1,0 +1,109 @@
+// Host-side unit tests for abimc_render. Run with: pio test -e native
+#include <unity.h>
+
+#include <abimc_render.h>
+
+using abimc::computeHand;
+using abimc::FRACTIONAL_BRIGHTNESS;
+using abimc::HandContribution;
+using abimc::mod;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_mod_wraps_negatives_into_range(void) {
+  TEST_ASSERT_EQUAL_INT64(9, mod(-1, 10));
+  TEST_ASSERT_EQUAL_INT64(0, mod(10, 10));
+  TEST_ASSERT_EQUAL_INT64(5, mod(25, 10));
+  TEST_ASSERT_EQUAL_INT64(7, mod(-3, 10));
+}
+
+void test_mod_guards_nonpositive_modulus(void) {
+  TEST_ASSERT_EQUAL_INT64(0, mod(5, 0));
+  TEST_ASSERT_EQUAL_INT64(0, mod(5, -3));
+}
+
+void test_compute_hand_rejects_bad_input(void) {
+  HandContribution out[8];
+  TEST_ASSERT_EQUAL_INT(0, computeHand(1, 0, /*period=*/0, 10, 0, out));
+  TEST_ASSERT_EQUAL_INT(0, computeHand(1, 0, /*period=*/-1, 10, 0, out));
+  TEST_ASSERT_EQUAL_INT(0, computeHand(1, 0, 1000, /*pixels=*/0, 0, out));
+}
+
+void test_compute_hand_at_period_start(void) {
+  // millis == 0 -> the hand sits exactly on pixel 0.
+  HandContribution out[8];
+  int n = computeHand(/*width=*/1, /*offset=*/0, /*period=*/1000, /*pixels=*/10,
+                      /*millis=*/0, out);
+  TEST_ASSERT_EQUAL_INT(2, n);
+  TEST_ASSERT_EQUAL_INT(0, out[0].index);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0].fadeBy);  // leading edge full brightness
+  TEST_ASSERT_EQUAL_INT(1, out[1].index);
+  // trailing edge fully faded (FRACTIONAL_BRIGHTNESS - 1)
+  TEST_ASSERT_EQUAL_UINT8(FRACTIONAL_BRIGHTNESS - 1, out[1].fadeBy);
+}
+
+void test_compute_hand_lands_on_whole_pixel(void) {
+  // Half a period on a 10-pixel ring -> exactly pixel 5, no fractional fade.
+  HandContribution out[8];
+  int n = computeHand(1, 0, 1000, 10, 500, out);
+  TEST_ASSERT_EQUAL_INT(2, n);
+  TEST_ASSERT_EQUAL_INT(5, out[0].index);
+  TEST_ASSERT_EQUAL_UINT8(0, out[0].fadeBy);
+  TEST_ASSERT_EQUAL_INT(6, out[1].index);
+  TEST_ASSERT_EQUAL_UINT8(FRACTIONAL_BRIGHTNESS - 1, out[1].fadeBy);
+}
+
+void test_compute_hand_sub_pixel_fade(void) {
+  // travel = 502 * (10*255) / 1000 = 1280 sub-pixels = pixel 5 + 5 sub-pixels.
+  HandContribution out[8];
+  int n = computeHand(1, 0, 1000, 10, 502, out);
+  TEST_ASSERT_EQUAL_INT(2, n);
+  TEST_ASSERT_EQUAL_INT(5, out[0].index);
+  TEST_ASSERT_EQUAL_UINT8(5, out[0].fadeBy);
+  TEST_ASSERT_EQUAL_INT(6, out[1].index);
+  TEST_ASSERT_EQUAL_UINT8(FRACTIONAL_BRIGHTNESS - 1 - 5, out[1].fadeBy);
+}
+
+void test_compute_hand_wraps_around_ring(void) {
+  // Near the end of the period the hand straddles pixel 9 -> pixel 0.
+  HandContribution out[8];
+  int n = computeHand(1, 0, 1000, 10, 999, out);
+  TEST_ASSERT_EQUAL_INT(2, n);
+  TEST_ASSERT_EQUAL_INT(9, out[0].index);
+  TEST_ASSERT_EQUAL_INT(0, out[1].index);  // wrapped back to the start
+}
+
+void test_compute_hand_interior_pixels_full_brightness(void) {
+  // A wider hand: only the first and last LEDs are faded.
+  HandContribution out[8];
+  int n = computeHand(/*width=*/3, 0, 1000, 24, 502, out);
+  TEST_ASSERT_EQUAL_INT(4, n);
+  TEST_ASSERT_EQUAL_UINT8(0, out[1].fadeBy);
+  TEST_ASSERT_EQUAL_UINT8(0, out[2].fadeBy);
+  TEST_ASSERT_NOT_EQUAL(0, out[0].fadeBy);
+  TEST_ASSERT_NOT_EQUAL(0, out[3].fadeBy);
+}
+
+void test_compute_hand_negative_offset(void) {
+  // A negative offset must still map into a valid pixel range.
+  HandContribution out[8];
+  int n = computeHand(1, /*offset=*/-255, 1000, 10, 0, out);
+  TEST_ASSERT_EQUAL_INT(2, n);
+  TEST_ASSERT_TRUE(out[0].index >= 0 && out[0].index < 10);
+  TEST_ASSERT_TRUE(out[1].index >= 0 && out[1].index < 10);
+}
+
+int main(int, char**) {
+  UNITY_BEGIN();
+  RUN_TEST(test_mod_wraps_negatives_into_range);
+  RUN_TEST(test_mod_guards_nonpositive_modulus);
+  RUN_TEST(test_compute_hand_rejects_bad_input);
+  RUN_TEST(test_compute_hand_at_period_start);
+  RUN_TEST(test_compute_hand_lands_on_whole_pixel);
+  RUN_TEST(test_compute_hand_sub_pixel_fade);
+  RUN_TEST(test_compute_hand_wraps_around_ring);
+  RUN_TEST(test_compute_hand_interior_pixels_full_brightness);
+  RUN_TEST(test_compute_hand_negative_offset);
+  return UNITY_END();
+}


### PR DESCRIPTION
First slice of **Track B — library extraction**. Goal: make the clock's logic framework-agnostic and host-testable. This PR stands up the host-test pipeline and extracts the trickiest pure piece — the hand-positioning geometry — with no behavior change to the firmware.

## What's here
- **New `lib/abimc_render`** — a FastLED/Arduino-free library with:
  - `abimc::mod()` — positive modulo
  - `abimc::computeHand()` — given hand width, ring size, period, and elapsed time, returns the lit pixels plus the sub-pixel leading/trailing fade and ring wrap-around. This is the exact math previously inlined in `updateStrand()`.
- **`src/main.cpp` refactored** — `updateStrand()` now calls `computeHand()` and only applies the color via FastLED. Behavior is identical (verified the math against the original line-by-line).
- **Host unit tests** — `test/test_render/` (Unity) covering mod, sub-pixel fade, ring wrap, interior-pixel brightness, negative offset, and input guards.
- **`native` PlatformIO env + CI** — CI now runs `pio test -e native` alongside the firmware build. `default_envs` pins `pio run` to the board so the native env never tries to compile the Arduino firmware.

## Verification
- `pio run -e adafruit_itsybitsy_m4` — firmware still builds (CI).
- `pio test -e native` — host tests (CI).
- Locally I also compiled the library standalone under `g++ -Wall -Wextra` and ran the same assertions — all pass. (PlatformIO isn't available in the dev environment, so CI is the first run of the Unity harness itself.)

## Why this split
It separates the **testable integer geometry** (positions, sub-pixel fading, wrap) from FastLED color application. That's exactly where the planned renderer motion rules (capped-speed slewing, the 60-on-64 catch-up, leap-second pacing) will live — now with a real test suite to build them against.

## Not in this PR (tracked in ROADMAP)
Per-ring binary-bit selection, the seconds "ripple", and `AbimcTimekeeper`/`AbimcConfig` — follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HAJ28v8jXB5RJFHovDxZVg)_